### PR TITLE
new reports API URL too

### DIFF
--- a/lib/reportsv2.rb
+++ b/lib/reportsv2.rb
@@ -1,5 +1,5 @@
 module TogglV8
-  TOGGL_REPORTS_URL = 'https://toggl.com/reports/api/'
+  TOGGL_REPORTS_URL = 'https://api.track.toggl.com/reports/api/'
 
   class ReportsV2
     include TogglV8::Connection


### PR DESCRIPTION
Another API URL constant that needs updating. Tested as working ✅  (previous URL earlier today).